### PR TITLE
Use ansible_distribution var for docker repository

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -18,19 +18,19 @@
 
 - name: "add Docker repository key"
   get_url:
-    url: "https://download.docker.com/linux/debian/gpg"
+    url: "https://download.docker.com/linux/{{ ansible_distribution|lower }}/gpg"
     dest: /etc/apt/keyrings/docker.asc
     force: false
 
 - name: "clean old line without signed-by"
   lineinfile:
     path: /etc/apt/sources.list.d/docker.list
-    line: "deb [arch=amd64] https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable"
+    line: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable"
     state: absent
 
 - name: "add Docker repository"
   apt_repository:
-    repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable"
+    repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable"
     filename: 'docker'
     state: present
 


### PR DESCRIPTION
Changes "debian" for ansible_distribution variable, in order to work for other distributions (Ubuntu) aswell