### PR TITLE
Fixed docker daemon MTU resolving

### DIFF
--- a/templates/daemon.json.j2
+++ b/templates/daemon.json.j2
@@ -1,6 +1,6 @@
 {
 {# MTU is needed in OpenStack VMs #}
-  "mtu": {{ docker_daemon_mtu | default(ansible_facts['default_ipv4']) }},
+  "mtu": {{ docker_daemon_mtu | default(ansible_facts['default_ipv4']['mtu'] | default(1500)) }},
 {# sets logging into systemd-journald and syslog #}
   "log-driver": "journald",
   "log-opts": {


### PR DESCRIPTION
- Properly point to mtu property of default_ipv4 ansible fact.
- Fallback to 1500 in case it can't be resolved (seems to be default on many instances).